### PR TITLE
Add ExecuteStewards script and Tenderly simulation instructions  

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 MNEMONIC_INDEX=
 LEDGER_SENDER=
+PRIVATE_KEY=
+PRIVATE_KEY_SENDER=
 
 # Test rpc_endpoints
 RPC_MAINNET=https://rpc.flashbots.net

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,16 @@ deploy-v3-ethereum-payload-tenderly :; forge script scripts/AaveV3EthereumAction
 deploy-v3-ethereum-payload-mainnet :; forge script scripts/AaveV3EthereumActions.s.sol:DeployPayload --rpc-url mainnet --broadcast --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify --etherscan-api-key ${ETHERSCAN_API_KEY_MAINNET} -vvvv
 deploy-v3-ethereum-pending-strategies :; forge script scripts/AaveV3EthereumActions.s.sol:DeployEthWSTEthStrategies --rpc-url mainnet --broadcast --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify --etherscan-api-key ${ETHERSCAN_API_KEY_MAINNET} -vvvv
 deploy-v3-ethereum-eth-strategy-mod :; forge script scripts/AaveV3EthereumActions.s.sol:DeployEthStrategyMod --rpc-url mainnet --broadcast --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify --etherscan-api-key ${ETHERSCAN_API_KEY_MAINNET} -vvvv
+execute-v3-stewards-tenderly :; forge script scripts/AaveV3EthereumActions.s.sol:ExecuteStewards --rpc-url tenderly --broadcast --private-key ${PRIVATE_KEY} --sender ${PRIVATE_KEY_SENDER} -vvvv
+execute-v3-stewards-mainnet :; forge script scripts/AaveV3EthereumActions.s.sol:ExecuteStewards --rpc-url mainnet --broadcast --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify --etherscan-api-key ${ETHERSCAN_API_KEY_MAINNET} -vvvv
 
 # Utilities
 download :; cast etherscan-source --chain ${chain} -d src/etherscan/${chain}_${address} ${address}
 git-diff :
 	@mkdir -p diffs
 	@printf '%s\n%s\n%s\n' "\`\`\`diff" "$$(git diff --no-index --diff-algorithm=patience --ignore-space-at-eol ${before} ${after})" "\`\`\`" > diffs/${out}.md
+
+# Tenderly Utilities, node.js is optional to create tenderly fork
+set-balance-tenderly :; cast rpc --rpc-url tenderly tenderly_setBalance ${PRIVATE_KEY_SENDER} 0x3635c9adc5dea00000
+get-balance-tenderly :; cast balance --rpc-url tenderly ${PRIVATE_KEY_SENDER}
+create-fork-proposal :; npx aave-tenderly-cli --proposalId 147 --blockNumber 16469126 --networkId 1 --keepAlive

--- a/README.md
+++ b/README.md
@@ -21,3 +21,30 @@ forge install
 ```sh
 make test
 ```
+
+## Tenderly fork simulation
+
+1. Fill your `.env` with a throwaway private key at `$PRIVATE_KEY` and the private key address at `$PRIVATE_KEY_SENDER`. You could use default accounts provided by Anvil.
+2. Create a fork with the executed proposal. If you have Node.js installed you can create a Tenderly fork with the next command:
+    > To load your Tenderly credentials, follow instructions to setup `aave-tenderly-cli` at the [README](https://github.com/bgd-labs/aave-tenderly-cli#setup-env).
+    ```
+    make create-fork-proposal
+    ```
+3. Copy the `rpcUrl` field from the output of the previous command and set the `$RPC_TENDERLY` environment variable at your `.env` file.
+3. Send 1000 Ether to your address at Tenderly fork:
+    ```
+    make set-balance-tenderly
+    ```
+4. Retrieve your Ether balance at Tenderly fork:
+    ```
+    make get-balance-tenderly
+    ```
+5. Execute each Steward in the Tenderly fork to list assets
+    ```
+    make execute-v3-stewards-tenderly
+    ```
+6. After succesful execution of the Stewards, the following command should return 7 listed assets:
+    ```
+    cast call --rpc-url tenderly 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2 "getReservesList()(address[])"
+    ```
+7. Perform any other validations in the fork.

--- a/scripts/AaveV3EthereumActions.s.sol
+++ b/scripts/AaveV3EthereumActions.s.sol
@@ -7,6 +7,7 @@ import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
 import {DefaultReserveInterestRateStrategy} from 'aave-v3-core/contracts/protocol/pool/DefaultReserveInterestRateStrategy.sol';
 import {AaveV3EthereumInitialPayload} from '../src/contracts/AaveV3EthereumInitialPayload.sol';
 import {AaveV3EthereumRateStrategiesDefinition} from '../src/contracts/AaveV3EthereumRateStrategiesDefinition.sol';
+import {BaseV3EthereumWithPoolAdmin} from '../src/contracts/stewards/BaseV3EthereumWithPoolAdmin.sol';
 
 contract DeployEngine is Script {
   function run() external {
@@ -80,6 +81,48 @@ contract DeployEthStrategyMod is Script {
       config.stableRateExcessOffset,
       config.optimalStableToTotalDebtRatio
     );
+
+    vm.stopBroadcast();
+  }
+}
+
+contract ExecuteStewards is Script {
+  function run() external {
+    AaveV3EthereumInitialPayload payloadAddress = AaveV3EthereumInitialPayload(
+      0xC5A0BA13A3749c5d4a21934df8Fd64821AC3fCE7
+    );
+
+    BaseV3EthereumWithPoolAdmin usdcSteward = BaseV3EthereumWithPoolAdmin(
+      payloadAddress.USDC_STEWARD()
+    );
+    BaseV3EthereumWithPoolAdmin daiSteward = BaseV3EthereumWithPoolAdmin(
+      payloadAddress.DAI_STEWARD()
+    );
+    BaseV3EthereumWithPoolAdmin wethSteward = BaseV3EthereumWithPoolAdmin(
+      payloadAddress.WETH_STEWARD()
+    );
+    BaseV3EthereumWithPoolAdmin wstEthSteward = BaseV3EthereumWithPoolAdmin(
+      payloadAddress.WSTETH_STEWARD()
+    );
+    BaseV3EthereumWithPoolAdmin wbtcSteward = BaseV3EthereumWithPoolAdmin(
+      payloadAddress.WBTC_STEWARD()
+    );
+    BaseV3EthereumWithPoolAdmin linkSteward = BaseV3EthereumWithPoolAdmin(
+      payloadAddress.LINK_STEWARD()
+    );
+    BaseV3EthereumWithPoolAdmin aaveSteward = BaseV3EthereumWithPoolAdmin(
+      payloadAddress.AAVE_STEWARD()
+    );
+
+    vm.startBroadcast();
+
+    usdcSteward.execute();
+    daiSteward.execute();
+    wethSteward.execute();
+    wstEthSteward.execute();
+    wbtcSteward.execute();
+    linkSteward.execute();
+    aaveSteward.execute();
 
     vm.stopBroadcast();
   }


### PR DESCRIPTION
- Add `ExecuteStewards` solidity script
- Add make commands to execute Stewards with Tenderly and mainnet
- Add docs to explain how to simulate the execution of the proposal 147 and execute the deployed Stewards with Tenderly


## Tenderly fork simulation

1. Fill your `.env` with a throwaway private key at `$PRIVATE_KEY` and the private key address at `$PRIVATE_KEY_SENDER`. You could use default accounts provided by Anvil.
2. Create a fork with the executed proposal. If you have Node.js installed you can create a Tenderly fork with the next command:
    > To load your Tenderly credentials, follow instructions to setup `aave-tenderly-cli` at the [README](https://github.com/bgd-labs/aave-tenderly-cli#setup-env).
    ```
    make create-fork-proposal
    ```
3. Copy the `rpcUrl` field from the output of the previous command and set the `$RPC_TENDERLY` environment variable at your `.env` file.
3. Send 1000 Ether to your address at Tenderly fork:
    ```
    make set-balance-tenderly
    ```
4. Retrieve your Ether balance at Tenderly fork:
    ```
    make get-balance-tenderly
    ```
5. Execute each Steward in the Tenderly fork to list assets
    ```
    make execute-v3-stewards-tenderly
    ```
6. After succesful execution of the Stewards, the following command should return 7 listed assets:
    ```
    cast call --rpc-url tenderly 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2 "getReservesList()(address[])"
    ```
7. Perform any other validations in the fork.